### PR TITLE
[DT-040319] Microsoft Exchange Office 365 Module

### DIFF
--- a/Decisions.Microsoft365.Exchange/ExchangeSettings.cs
+++ b/Decisions.Microsoft365.Exchange/ExchangeSettings.cs
@@ -41,12 +41,12 @@ namespace Decisions.Microsoft365.Exchange
         }
 
         [ORMField]
-        private string tokenId;
+        private string? tokenId;
 
         [WritableValue]
         [PropertyClassification(new string[] { "Credentials" }, "OAuth Token", 1)]
         [TokenPicker]
-        public string TokenId
+        public string? TokenId
         {
             get => tokenId;
             set
@@ -56,7 +56,7 @@ namespace Decisions.Microsoft365.Exchange
             }
         }
         
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void OnPropertyChanged(string propertyName)
         {
@@ -66,6 +66,11 @@ namespace Decisions.Microsoft365.Exchange
         public ValidationIssue[] GetValidationIssues()
         {
             List<ValidationIssue> issues = new List<ValidationIssue>();
+
+            if (string.IsNullOrEmpty(GraphUrl))
+            {
+                issues.Add(new ValidationIssue("GraphURL cannot be empty."));
+            }
 
             return issues.ToArray();
         }

--- a/Decisions.Microsoft365.Exchange/Steps/CalendarSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/CalendarSteps.cs
@@ -10,7 +10,7 @@ namespace Decisions.Microsoft365.Exchange.Steps
     [AutoRegisterMethodsOnClass(true, "Integration/Microsoft365/Exchange/Calendar")]
     public class CalendarSteps
     {
-        private static JsonSerializerSettings IgnoreNullValues = new()
+        private static readonly JsonSerializerSettings IgnoreNullValues = new()
         {
             NullValueHandling = NullValueHandling.Ignore
         };

--- a/Decisions.Microsoft365.Exchange/Steps/EmailSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/EmailSteps.cs
@@ -165,7 +165,7 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
 
-        protected virtual Microsoft365Recipient[]? GetRecipients(string[] emailAddresses)
+        private Microsoft365Recipient[]? GetRecipients(string[] emailAddresses)
         {
             List<Microsoft365Recipient> recipients = new List<Microsoft365Recipient>();
             if (emailAddresses.Length > 0)

--- a/Decisions.Microsoft365.Exchange/Steps/EmailSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/EmailSteps.cs
@@ -48,7 +48,7 @@ namespace Decisions.Microsoft365.Exchange.Steps
             Microsoft365EmailList? response = JsonHelper<Microsoft365EmailList?>.JsonDeserialize(result);
 
             List<Microsoft365Message>? messages = new List<Microsoft365Message>();
-            foreach (Microsoft365Message email in response.Value)
+            foreach (Microsoft365Message email in response?.Value!)
             {
                 if (email.IsRead is false or null)
                 {
@@ -152,7 +152,7 @@ namespace Decisions.Microsoft365.Exchange.Steps
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetEmailUrl(userIdentifier, messageId, mailFolderId)}/forward";
 
-            Microsoft365Recipient[] recipients = GetRecipients(to);
+            Microsoft365Recipient[] recipients = GetRecipients(to)!;
             Microsoft365ForwardRequest microsoft365ForwardRequest = new()
             {
                 Comment = comment,
@@ -164,8 +164,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
 
             return response.StatusCode.ToString();
         }
-        
-        private Microsoft365Recipient[]? GetRecipients(string[] emailAddresses)
+
+        protected virtual Microsoft365Recipient[]? GetRecipients(string[] emailAddresses)
         {
             List<Microsoft365Recipient> recipients = new List<Microsoft365Recipient>();
             if (emailAddresses.Length > 0)

--- a/Decisions.Microsoft365.Exchange/Steps/GroupSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/GroupSteps.cs
@@ -2,7 +2,9 @@ using System.Net.Http.Json;
 using System.Text;
 using Decisions.Microsoft365.Common;
 using Decisions.Microsoft365.Common.API.Group;
+using DecisionsFramework;
 using DecisionsFramework.Design.Flow;
+using DecisionsFramework.Design.Properties;
 using DecisionsFramework.ServiceLayer;
 using Newtonsoft.Json;
 
@@ -11,12 +13,13 @@ namespace Decisions.Microsoft365.Exchange.Steps
     [AutoRegisterMethodsOnClass(true, "Integration/Microsoft365/Exchange/Groups")]
     public class GroupSteps
     {
-        private static JsonSerializerSettings IgnoreNullValues = new()
+        private static readonly JsonSerializerSettings IgnoreNullValues = new()
         {
             NullValueHandling = NullValueHandling.Ignore
         };
         
-        public Microsoft365GroupList? ListGroups(ExchangeSettings? settingsOverride, bool filterUnified)
+        public Microsoft365GroupList? ListGroups(bool filterUnified,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride = null)
         {
             string urlExtension = (filterUnified) ? $"{Microsoft365UrlHelper.GetGroupUrl(null)}$filter=groupTypes/any(c:c+eq+'Unified')" : Microsoft365UrlHelper.GetGroupUrl(null);
             string result = GraphRest.Get(settingsOverride, urlExtension);
@@ -24,10 +27,19 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365GroupList?>.JsonDeserialize(result);
         }
         
-        public Microsoft365Group? CreateGroup(ExchangeSettings? settingsOverride,
-            string? description, string displayName, string[]? groupTypes, bool mailEnabled, string mailNickname,
-            bool securityEnabled, string[]? ownerIds, string[]? memberIds)
+        public Microsoft365Group? CreateGroup(string? description, string displayName, string[]? groupTypes,
+            bool? mailEnabled, string mailNickname, bool? securityEnabled, string[]? ownerIds, string[]? memberIds,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
+            if (string.IsNullOrEmpty(mailNickname))
+            {
+                throw new BusinessRuleException("mailNickname cannot be null or empty. Please set a unique nickname.");
+            }
+            
+            mailEnabled ??= false;
+            securityEnabled ??= false;
+            groupTypes ??= Array.Empty<string>();
+            
             string[]? owners = (ownerIds != null) ? GetUserUrlStrings(ownerIds) : Array.Empty<string>();
             string[]? members = (memberIds != null) ? GetUserUrlStrings(memberIds) : Array.Empty<string>();
             
@@ -49,7 +61,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365Group?>.JsonDeserialize(result);
         }
         
-        public Microsoft365Group? GetGroup(ExchangeSettings? settingsOverride, string groupId)
+        public Microsoft365Group? GetGroup(string groupId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetGroupUrl(groupId);
             string result = GraphRest.Get(settingsOverride, urlExtension);
@@ -57,18 +70,23 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365Group?>.JsonDeserialize(result);
         }
         
-        public string UpdateGroup(ExchangeSettings? settingsOverride, string groupId, Microsoft365UpdateGroup group)
+        public string UpdateGroup(string groupId, Microsoft365UpdateGroup group,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetGroupUrl(groupId);
+
+            // Some objects can only be patched individually, so separate requests will be made.
+            LesserGroupUpdates(settingsOverride, urlExtension, group);
             
-            HttpContent content = new StringContent(JsonConvert.SerializeObject(group, IgnoreNullValues), Encoding.UTF8,
-                "application/json");
+            HttpContent content = new StringContent(JsonConvert.SerializeObject(group, IgnoreNullValues),
+                Encoding.UTF8, "application/json");
             HttpResponseMessage response = GraphRest.HttpResponsePatch(settingsOverride, urlExtension, content);
             
             return response.StatusCode.ToString();
         }
         
-        public string DeleteGroup(ExchangeSettings? settingsOverride, string groupId)
+        public string DeleteGroup(string groupId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetGroupUrl(groupId);
             HttpResponseMessage response = GraphRest.Delete(settingsOverride, urlExtension);
@@ -76,7 +94,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
         
-        public Microsoft365MemberList? ListMembers(ExchangeSettings? settingsOverride, string groupId)
+        public Microsoft365MemberList? ListMembers(string groupId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetGroupUrl(groupId)}/members";
             string result = GraphRest.Get(settingsOverride, urlExtension);
@@ -84,7 +103,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365MemberList?>.JsonDeserialize(result);
         }
         
-        public string AddMembers(ExchangeSettings? settingsOverride, string groupId, string[] directoryObjectIds)
+        public string AddMembers(string groupId, string[] directoryObjectIds,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetGroupUrl(groupId);
 
@@ -105,7 +125,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
         
-        public string RemoveMember(ExchangeSettings? settingsOverride, string groupId, string directoryObjectId)
+        public string RemoveMember(string groupId, string directoryObjectId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetGroupUrl(groupId)}/members/{directoryObjectId}/$ref";
             HttpResponseMessage response = GraphRest.Delete(settingsOverride, urlExtension);
@@ -113,7 +134,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
         
-        public Microsoft365GroupCollection? ListMemberOf(ExchangeSettings? settingsOverride, string userIdentifier)
+        public Microsoft365GroupCollection? ListMemberOf(string userIdentifier,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/memberOf";
             string result = GraphRest.Get(settingsOverride, urlExtension);
@@ -130,6 +152,26 @@ namespace Decisions.Microsoft365.Exchange.Steps
             }
 
             return userUrls.ToArray();
+        }
+
+        private void LesserGroupUpdates(ExchangeSettings? settingsOverride, string urlExtension, Microsoft365UpdateGroup group)
+        {
+            List<Microsoft365UpdateGroup> lesserGroups = new List<Microsoft365UpdateGroup>();
+            if (group.AllowExternalSenders != null)
+            {
+                lesserGroups.Add(new() { AllowExternalSenders = group.AllowExternalSenders });
+            }
+            if (group.AutoSubscribeNewMembers != null)
+            {
+                lesserGroups.Add(new() { AutoSubscribeNewMembers = group.AutoSubscribeNewMembers});
+            }
+
+            foreach (Microsoft365UpdateGroup lesserGroup in lesserGroups)
+            {
+                HttpContent content = new StringContent(JsonConvert.SerializeObject(lesserGroup, IgnoreNullValues),
+                    Encoding.UTF8, "application/json");
+                GraphRest.HttpResponsePatch(settingsOverride, urlExtension, content);
+            }
         }
     }
 }

--- a/Decisions.Microsoft365.Exchange/Steps/GroupSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/GroupSteps.cs
@@ -33,7 +33,7 @@ namespace Decisions.Microsoft365.Exchange.Steps
         {
             if (string.IsNullOrEmpty(mailNickname))
             {
-                throw new BusinessRuleException("mailNickname cannot be null or empty. Please set a unique nickname.");
+                throw new BusinessRuleException("Mail Nickname cannot be null or empty. Please set a unique Mail Nickname.");
             }
             
             mailEnabled ??= false;


### PR DESCRIPTION
Fixes for CreateGroup and UpdateGroup - Filters certain variables from null to false and creates separate requests for updating variables that require individual patch calls.