### PR TITLE
[DT-040319] Microsoft Exchange Office 365 Module

### DIFF
--- a/Decisions.Microsoft365.Exchange/Steps/CalendarSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/CalendarSteps.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Decisions.Microsoft365.Common;
 using Decisions.Microsoft365.Common.API.Calendar;
 using DecisionsFramework.Design.Flow;
+using DecisionsFramework.Design.Properties;
 using Newtonsoft.Json;
 
 namespace Decisions.Microsoft365.Exchange.Steps
@@ -15,8 +16,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             NullValueHandling = NullValueHandling.Ignore
         };
         
-        public Microsoft365Event? CreateCalendarEvent(ExchangeSettings? settingsOverride,
-            Microsoft365CalendarEvent microsoft365CalendarEvent, string userIdentifier, string? calendarId)
+        public Microsoft365Event? CreateCalendarEvent(Microsoft365CalendarEvent microsoft365CalendarEvent, string userIdentifier, string? calendarId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetCalendarEventUrl(userIdentifier, null, calendarId, null);
             
@@ -26,8 +27,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365Event?>.JsonDeserialize(result);
         }
 
-        public string DeleteCalendarEvent(ExchangeSettings? settingsOverride, string userIdentifier, string eventId,
-            string? calendarId, string? calendarGroupId)
+        public string DeleteCalendarEvent(string userIdentifier, string eventId, string? calendarId, string? calendarGroupId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetCalendarEventUrl(userIdentifier, eventId, calendarId, calendarGroupId);
 
@@ -36,8 +37,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
         
-        public Microsoft365EventList? ListCalendarEvents(ExchangeSettings? settingsOverride,
-            string userIdentifier, string? calendarId, string? calendarGroupId)
+        public Microsoft365EventList? ListCalendarEvents(string userIdentifier, string? calendarId, string? calendarGroupId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetCalendarEventUrl(userIdentifier, null, calendarId, calendarGroupId);
             string result = GraphRest.Get(settingsOverride, urlExtension);
@@ -45,9 +46,9 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365EventList?>.JsonDeserialize(result);
         }
 
-        public Microsoft365Event? UpdateCalendarEvent(ExchangeSettings? settingsOverride,
-            string userIdentifier, string eventId, string? calendarId, string? calendarGroupId,
-            Microsoft365UpdateCalendarEvent calendarEventMicrosoft365Update)
+        public Microsoft365Event? UpdateCalendarEvent(string userIdentifier, string eventId, string? calendarId, string?
+            calendarGroupId, Microsoft365UpdateCalendarEvent calendarEventMicrosoft365Update,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetCalendarEventUrl(userIdentifier, eventId, calendarId, calendarGroupId);
             
@@ -59,7 +60,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365Event?>.JsonDeserialize(result);
         }
         
-        public Microsoft365CalendarList? ListCalendars(ExchangeSettings? settingsOverride, string userIdentifier)
+        public Microsoft365CalendarList? ListCalendars(string userIdentifier,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/calendars";
             string result = GraphRest.Get(settingsOverride, urlExtension);

--- a/Decisions.Microsoft365.Exchange/Steps/ContactSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/ContactSteps.cs
@@ -3,14 +3,15 @@ using Decisions.Microsoft365.Common;
 using Decisions.Microsoft365.Common.API.People;
 using DecisionsFramework;
 using DecisionsFramework.Design.Flow;
+using DecisionsFramework.Design.Properties;
 
 namespace Decisions.Microsoft365.Exchange.Steps
 {
     [AutoRegisterMethodsOnClass(true, "Integration/Microsoft365/Exchange/Contacts")]
     public class ContactSteps
     {
-        public string CreateContact(ExchangeSettings? settingsOverride, string userIdentifier,
-            string? contactFolderId, Microsoft365ContactRequest contactRequest)
+        public string CreateContact(string userIdentifier, string? contactFolderId, Microsoft365ContactRequest contactRequest,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetContactUrl(userIdentifier, null, contactFolderId, null);
             
@@ -20,7 +21,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
 
-        public string DeleteContact(ExchangeSettings? settingsOverride, string userIdentifier, string? contactId)
+        public string DeleteContact(string userIdentifier, string? contactId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetContactUrl(userIdentifier, contactId, null, null);
             HttpResponseMessage response = GraphRest.Delete(settingsOverride, urlExtension);
@@ -28,8 +30,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
 
-        public Microsoft365Contact? GetContact(ExchangeSettings? settingsOverride, string userIdentifier,
-            string contactId, string? contactFolderId, string? childFolderId, string? expandQuery)
+        public Microsoft365Contact? GetContact(string userIdentifier, string contactId, string? contactFolderId, string? childFolderId, string? expandQuery,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetContactUrl(userIdentifier, contactId, contactFolderId, childFolderId);
 
@@ -43,7 +45,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365Contact?>.JsonDeserialize(result);
         }
 
-        public Microsoft365ContactList? ListContacts(ExchangeSettings? settingsOverride, string userIdentifier)
+        public Microsoft365ContactList? ListContacts(string userIdentifier,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetContactUrl(userIdentifier, null, null, null);
             string result = GraphRest.Get(settingsOverride, urlExtension);
@@ -51,8 +54,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365ContactList?>.JsonDeserialize(result);
         }
         
-        public Microsoft365ContactList? SearchContacts(ExchangeSettings? settingsOverride,
-            string userIdentifier, string searchQuery)
+        public Microsoft365ContactList? SearchContacts(string userIdentifier, string searchQuery,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             if (string.IsNullOrEmpty(searchQuery))
             {
@@ -65,8 +68,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365ContactList?>.JsonDeserialize(result);
         }
 
-        public Microsoft365PeopleList? SearchGlobalContacts(ExchangeSettings? settingsOverride,
-            string userIdentifier, string searchQuery)
+        public Microsoft365PeopleList? SearchGlobalContacts(string userIdentifier, string searchQuery,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             if (string.IsNullOrEmpty(searchQuery))
             {

--- a/Decisions.Microsoft365.Exchange/Steps/EmailSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/EmailSteps.cs
@@ -3,14 +3,15 @@ using Decisions.Microsoft365.Common;
 using Decisions.Microsoft365.Common.API.Email;
 using DecisionsFramework;
 using DecisionsFramework.Design.Flow;
+using DecisionsFramework.Design.Properties;
 
 namespace Decisions.Microsoft365.Exchange.Steps
 {
     [AutoRegisterMethodsOnClass(true, "Integration/Microsoft365/Exchange/Email")]
     public class EmailSteps
     {
-        public Microsoft365Message? GetEmail(ExchangeSettings? settingsOverride,
-            string userIdentifier, string messageId)
+        public Microsoft365Message? GetEmail(string userIdentifier, string messageId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/messages/{messageId}";
             string result = GraphRest.Get(settingsOverride, urlExtension);
@@ -18,8 +19,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365Message?>.JsonDeserialize(result);
         }
         
-        public Microsoft365EmailList? SearchEmails(ExchangeSettings? settingsOverride,
-            string userIdentifier, string searchQuery)
+        public Microsoft365EmailList? SearchEmails(string userIdentifier, string searchQuery,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             if (string.IsNullOrEmpty(searchQuery))
             {
@@ -32,7 +33,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365EmailList?>.JsonDeserialize(result);
         }
         
-        public Microsoft365EmailList? ListEmails(ExchangeSettings? settingsOverride, string userIdentifier)
+        public Microsoft365EmailList? ListEmails(string userIdentifier,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/messages";
             string result = GraphRest.Get(settingsOverride, urlExtension);
@@ -40,7 +42,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return JsonHelper<Microsoft365EmailList?>.JsonDeserialize(result);
         }
         
-        public Microsoft365EmailList ListUnreadEmails(ExchangeSettings? settingsOverride, string userIdentifier)
+        public Microsoft365EmailList ListUnreadEmails(string userIdentifier,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/messages";
             string result = GraphRest.Get(settingsOverride, urlExtension);
@@ -65,7 +68,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return unreadEmails;
         }
         
-        public string MarkEmailAsRead(ExchangeSettings? settingsOverride, string userIdentifier, string messageId)
+        public string MarkEmailAsRead(string userIdentifier, string messageId,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/messages/{messageId}";
             
@@ -75,8 +79,9 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
         
-        public string SendEmail(ExchangeSettings? settingsOverride, string userIdentifier,
-            string[] to, string[]? cc, string subject, string? body, Microsoft365BodyType? contentType, bool saveToSentItems)
+        public string SendEmail(string userIdentifier, string[] to, string[]? cc, string subject, string? body,
+            Microsoft365BodyType? contentType, bool saveToSentItems,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/sendMail";
             
@@ -105,9 +110,9 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
         
-        public string SendReply(ExchangeSettings? settingsOverride, string userIdentifier,
-            string? mailFolderId, string messageId, string[] to, string[]? cc, string subject, string? body,
-            Microsoft365BodyType? contentType, bool saveToSentItems)
+        public string SendReply(string userIdentifier, string? mailFolderId, string messageId, string[] to, string[]? cc,
+            string subject, string? body, Microsoft365BodyType? contentType, bool saveToSentItems,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetEmailUrl(userIdentifier, messageId, mailFolderId)}/reply";
             
@@ -136,8 +141,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
         
-        public string SendReplyToAll(ExchangeSettings? settingsOverride, string userIdentifier,
-            string? mailFolderId, string messageId, string? comment)
+        public string SendReplyToAll(string userIdentifier, string? mailFolderId, string messageId, string? comment,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetEmailUrl(userIdentifier, messageId, mailFolderId)}/replyAll";
             
@@ -147,8 +152,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
             return response.StatusCode.ToString();
         }
         
-        public string ForwardEmail(ExchangeSettings? settingsOverride, string userIdentifier,
-            string messageId, string? mailFolderId, string[] to, string comment)
+        public string ForwardEmail(string userIdentifier, string messageId, string? mailFolderId, string[] to, string comment,
+            [PropertyClassification(0, "Settings Override", "Settings")] ExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetEmailUrl(userIdentifier, messageId, mailFolderId)}/forward";
 

--- a/Decisions.Microsoft365.Exchange/Steps/GroupSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/GroupSteps.cs
@@ -119,7 +119,8 @@ namespace Decisions.Microsoft365.Exchange.Steps
                 Members = memberList.ToArray()
             };
 
-            JsonContent content = JsonContent.Create(membersRequest);
+            HttpContent content = new StringContent(JsonConvert.SerializeObject(membersRequest, IgnoreNullValues),
+                Encoding.UTF8, "application/json");
             HttpResponseMessage response = GraphRest.HttpResponsePatch(settingsOverride, urlExtension, content);
 
             return response.StatusCode.ToString();


### PR DESCRIPTION
'Add Members' step fixed. 'Update Calendar Event' step worked correctly when using correct IDs, so an update was made to 'List Calendar Events' output type in the Microsoft365.Common module.

Settings Override inputs moved to their own input category on steps where it was previously not applied.