### PR TITLE
[DT-041822] Exchange module steps will error out when attempting to use a global token

### DIFF
--- a/Decisions.Microsoft365.Exchange/GraphRest.cs
+++ b/Decisions.Microsoft365.Exchange/GraphRest.cs
@@ -65,7 +65,7 @@ namespace Decisions.Microsoft365.Exchange
             ExchangeSettings settings = GetSettings(settingsOverride);
             OAuthToken token = new ORM<OAuthToken>().Fetch(settings.TokenId);
             
-            string tokenHeader = OAuth2Utility.GetOAuth2HeaderValue(token?.TokenData, "Bearer");
+            string tokenHeader = OAuth2Utility.GetOAuth2HeaderValue(token.TokenData, "Bearer");
 
             HttpClient client = HttpClients.GetHttpClient(HttpClientAuthType.Normal);
 

--- a/Decisions.Microsoft365.Exchange/GraphRest.cs
+++ b/Decisions.Microsoft365.Exchange/GraphRest.cs
@@ -65,7 +65,7 @@ namespace Decisions.Microsoft365.Exchange
             ExchangeSettings settings = GetSettings(settingsOverride);
             OAuthToken token = new ORM<OAuthToken>().Fetch(settings.TokenId);
             
-            string tokenHeader = OAuth2Utility.GetOAuth2HeaderValue(token.TokenData, "Bearer");
+            string tokenHeader = OAuth2Utility.GetOAuth2HeaderValue(token?.TokenData, "Bearer");
 
             HttpClient client = HttpClients.GetHttpClient(HttpClientAuthType.Normal);
 

--- a/Decisions.Microsoft365.Exchange/Microsoft365Utility.cs
+++ b/Decisions.Microsoft365.Exchange/Microsoft365Utility.cs
@@ -1,0 +1,13 @@
+namespace Decisions.Microsoft365.Exchange;
+
+public static class Microsoft365Utility
+{
+    internal static ExchangeSettings? GetExchangeSettings(InputExchangeSettings? settingsOverride)
+    {
+        var exchangeSettingsOverride = settingsOverride != null
+            ? new ExchangeSettings() { TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl }
+            : null;
+        
+        return exchangeSettingsOverride;
+    }
+}

--- a/Decisions.Microsoft365.Exchange/Steps/ExchangeCalenderSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/ExchangeCalenderSteps.cs
@@ -22,7 +22,7 @@ public class ExchangeCalenderSteps
             string urlExtension = Microsoft365UrlHelper.GetCalendarEventUrl(userIdentifier, null, calendarId, null);
             
             JsonContent content = JsonContent.Create(microsoft365CalendarEvent);
-            string result = GraphRest.Post(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            string result = GraphRest.Post(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
             
             return JsonHelper<Microsoft365Event?>.JsonDeserialize(result);
         }
@@ -32,7 +32,7 @@ public class ExchangeCalenderSteps
         {
             string urlExtension = Microsoft365UrlHelper.GetCalendarEventUrl(userIdentifier, eventId, calendarId, calendarGroupId);
 
-            HttpResponseMessage response = GraphRest.Delete(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            HttpResponseMessage response = GraphRest.Delete(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
 
             return response.StatusCode.ToString();
         }
@@ -41,7 +41,7 @@ public class ExchangeCalenderSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetCalendarEventUrl(userIdentifier, null, calendarId, calendarGroupId);
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365EventList?>.JsonDeserialize(result);
         }
@@ -55,7 +55,7 @@ public class ExchangeCalenderSteps
             HttpContent content = new StringContent(JsonConvert.SerializeObject(calendarEventMicrosoft365Update, IgnoreNullValues),
                 Encoding.UTF8, "application/json");
 
-            string result = GraphRest.Patch(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            string result = GraphRest.Patch(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
             
             return JsonHelper<Microsoft365Event?>.JsonDeserialize(result);
         }
@@ -64,7 +64,7 @@ public class ExchangeCalenderSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/calendars";
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365CalendarList?>.JsonDeserialize(result);
         }

--- a/Decisions.Microsoft365.Exchange/Steps/ExchangeContactSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/ExchangeContactSteps.cs
@@ -16,7 +16,7 @@ public class ExchangeContactSteps
             string urlExtension = Microsoft365UrlHelper.GetContactUrl(userIdentifier, null, contactFolderId, null);
             
             JsonContent content = JsonContent.Create(contactRequest);
-            HttpResponseMessage response = GraphRest.HttpResponsePost(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            HttpResponseMessage response = GraphRest.HttpResponsePost(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
             
             return response.StatusCode.ToString();
         }
@@ -25,7 +25,7 @@ public class ExchangeContactSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetContactUrl(userIdentifier, contactId, null, null);
-            HttpResponseMessage response = GraphRest.Delete(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            HttpResponseMessage response = GraphRest.Delete(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return response.StatusCode.ToString();
         }
@@ -40,7 +40,7 @@ public class ExchangeContactSteps
                 urlExtension = $"?$expand={expandQuery}";
             }
 
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365Contact?>.JsonDeserialize(result);
         }
@@ -49,7 +49,7 @@ public class ExchangeContactSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetContactUrl(userIdentifier, null, null, null);
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365ContactList?>.JsonDeserialize(result);
         }
@@ -63,7 +63,7 @@ public class ExchangeContactSteps
             }
             
             string urlExtension = $"{Microsoft365UrlHelper.GetContactUrl(userIdentifier, null, null, null)}?$search={searchQuery}";
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365ContactList?>.JsonDeserialize(result);
         }
@@ -77,7 +77,7 @@ public class ExchangeContactSteps
             }
             
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/people?$search={searchQuery}";
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365PeopleList?>.JsonDeserialize(result);
         }

--- a/Decisions.Microsoft365.Exchange/Steps/ExchangeEmailSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/ExchangeEmailSteps.cs
@@ -15,7 +15,7 @@ public class ExchangeEmailSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/messages/{messageId}";
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365Message?>.JsonDeserialize(result);
         }
@@ -30,7 +30,7 @@ public class ExchangeEmailSteps
             
             int pageCount = (int)((maxPageCount > 0) ? maxPageCount : 1);
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/messages?$search={searchQuery}";
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
 
             List<Microsoft365EmailList?> emailLists = new List<Microsoft365EmailList?>();
             emailLists?.Add(JsonHelper<Microsoft365EmailList?>.JsonDeserialize(result));
@@ -38,7 +38,7 @@ public class ExchangeEmailSteps
             Microsoft365EmailList? tempEmailList = emailLists.First();
             for (int i = 0; i <= pageCount - 1 && !string.IsNullOrEmpty(tempEmailList.OdataNextLink); i++)
             {
-                tempEmailList = ODataHelper<Microsoft365EmailList?>.GetNextPage(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, tempEmailList.OdataNextLink);
+                tempEmailList = ODataHelper<Microsoft365EmailList?>.GetNextPage(Microsoft365Utility.GetExchangeSettings(settingsOverride), tempEmailList.OdataNextLink);
                 emailLists.Add(tempEmailList);
             }
 
@@ -59,7 +59,7 @@ public class ExchangeEmailSteps
         {
             int pageCount = (int)((maxPageCount > 0) ? maxPageCount : 1);
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/messages";
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
 
             List<Microsoft365EmailList?> emailLists = new List<Microsoft365EmailList?>();
             emailLists?.Add(JsonHelper<Microsoft365EmailList?>.JsonDeserialize(result));
@@ -67,7 +67,7 @@ public class ExchangeEmailSteps
             Microsoft365EmailList? tempEmailList = emailLists.First();
             for (int i = 0; i <= pageCount - 1 && !string.IsNullOrEmpty(tempEmailList.OdataNextLink); i++)
             {
-                tempEmailList = ODataHelper<Microsoft365EmailList?>.GetNextPage(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, tempEmailList.OdataNextLink);
+                tempEmailList = ODataHelper<Microsoft365EmailList?>.GetNextPage(Microsoft365Utility.GetExchangeSettings(settingsOverride), tempEmailList.OdataNextLink);
                 emailLists.Add(tempEmailList);
             }
             
@@ -88,7 +88,7 @@ public class ExchangeEmailSteps
         {
             int pageCount = (int)((maxPageCount > 0) ? maxPageCount : 1);
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/messages";
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             List<Microsoft365EmailList?> emailLists = new List<Microsoft365EmailList?>();
             emailLists?.Add(JsonHelper<Microsoft365EmailList?>.JsonDeserialize(result));
@@ -96,7 +96,7 @@ public class ExchangeEmailSteps
             Microsoft365EmailList? tempEmailList = emailLists.First();
             for (int i = 0; i <= pageCount - 1 && !string.IsNullOrEmpty(tempEmailList.OdataNextLink); i++)
             {
-                tempEmailList = ODataHelper<Microsoft365EmailList?>.GetNextPage(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, tempEmailList.OdataNextLink);
+                tempEmailList = ODataHelper<Microsoft365EmailList?>.GetNextPage(Microsoft365Utility.GetExchangeSettings(settingsOverride), tempEmailList.OdataNextLink);
                 emailLists.Add(tempEmailList);
             }
 
@@ -121,7 +121,7 @@ public class ExchangeEmailSteps
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/messages/{messageId}";
             
             JsonContent content = JsonContent.Create(new Microsoft365EmailIsReadRequest{IsRead = true});
-            HttpResponseMessage response = GraphRest.HttpResponsePatch(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            HttpResponseMessage response = GraphRest.HttpResponsePatch(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
 
             return response.StatusCode.ToString();
         }
@@ -152,7 +152,7 @@ public class ExchangeEmailSteps
             };
             
             JsonContent content = JsonContent.Create(emailMessage);
-            HttpResponseMessage response = GraphRest.HttpResponsePost(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            HttpResponseMessage response = GraphRest.HttpResponsePost(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
 
             return response.StatusCode.ToString();
         }
@@ -183,7 +183,7 @@ public class ExchangeEmailSteps
             };
             
             JsonContent content = JsonContent.Create(emailMessage);
-            HttpResponseMessage response = GraphRest.HttpResponsePost(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            HttpResponseMessage response = GraphRest.HttpResponsePost(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
 
             return response.StatusCode.ToString();
         }
@@ -194,7 +194,7 @@ public class ExchangeEmailSteps
             string urlExtension = $"{Microsoft365UrlHelper.GetEmailUrl(userIdentifier, messageId, mailFolderId)}/replyAll";
             
             JsonContent content = JsonContent.Create(new Microsoft365EmailComment{Comment = comment});
-            HttpResponseMessage response = GraphRest.HttpResponsePost(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            HttpResponseMessage response = GraphRest.HttpResponsePost(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
 
             return response.StatusCode.ToString();
         }
@@ -212,7 +212,7 @@ public class ExchangeEmailSteps
             };
             
             JsonContent content = JsonContent.Create(microsoft365ForwardRequest);
-            HttpResponseMessage response = GraphRest.HttpResponsePost(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            HttpResponseMessage response = GraphRest.HttpResponsePost(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
 
             return response.StatusCode.ToString();
         }

--- a/Decisions.Microsoft365.Exchange/Steps/ExchangeGroupSteps.cs
+++ b/Decisions.Microsoft365.Exchange/Steps/ExchangeGroupSteps.cs
@@ -20,8 +20,8 @@ public class ExchangeGroupSteps
         public Microsoft365GroupList? ListGroups(bool filterUnified,
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride = null)
         {
-            string urlExtension = (filterUnified) ? $"{Microsoft365UrlHelper.GetGroupUrl(null)}$filter=groupTypes/any(c:c+eq+'Unified')" : Microsoft365UrlHelper.GetGroupUrl(null);
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string urlExtension = (filterUnified) ? $"{Microsoft365UrlHelper.GetGroupUrl(null)}$filter=groupTypes/any(c:c+eq+'Unified')" : Microsoft365UrlHelper.GetGroupUrl(null);                    
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365GroupList?>.JsonDeserialize(result);
         }
@@ -55,7 +55,7 @@ public class ExchangeGroupSteps
             };
             
             HttpContent content = new StringContent(groupRequest.JsonSerialize(), Encoding.UTF8, "application/json");
-            string result = GraphRest.Post(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, Microsoft365UrlHelper.GetGroupUrl(null), content);
+            string result = GraphRest.Post(Microsoft365Utility.GetExchangeSettings(settingsOverride), Microsoft365UrlHelper.GetGroupUrl(null), content);
 
             return JsonHelper<Microsoft365Group?>.JsonDeserialize(result);
         }
@@ -64,7 +64,7 @@ public class ExchangeGroupSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetGroupUrl(groupId);
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
 
             return JsonHelper<Microsoft365Group?>.JsonDeserialize(result);
         }
@@ -79,7 +79,7 @@ public class ExchangeGroupSteps
             
             HttpContent content = new StringContent(JsonConvert.SerializeObject(group, IgnoreNullValues),
                 Encoding.UTF8, "application/json");
-            HttpResponseMessage response = GraphRest.HttpResponsePatch(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            HttpResponseMessage response = GraphRest.HttpResponsePatch(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
             
             return response.StatusCode.ToString();
         }
@@ -88,7 +88,7 @@ public class ExchangeGroupSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = Microsoft365UrlHelper.GetGroupUrl(groupId);
-            HttpResponseMessage response = GraphRest.Delete(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            HttpResponseMessage response = GraphRest.Delete(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return response.StatusCode.ToString();
         }
@@ -97,7 +97,7 @@ public class ExchangeGroupSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetGroupUrl(groupId)}/members";
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365MemberList?>.JsonDeserialize(result);
         }
@@ -120,7 +120,7 @@ public class ExchangeGroupSteps
 
             HttpContent content = new StringContent(JsonConvert.SerializeObject(membersRequest, IgnoreNullValues),
                 Encoding.UTF8, "application/json");
-            HttpResponseMessage response = GraphRest.HttpResponsePatch(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension, content);
+            HttpResponseMessage response = GraphRest.HttpResponsePatch(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension, content);
 
             return response.StatusCode.ToString();
         }
@@ -129,7 +129,7 @@ public class ExchangeGroupSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetGroupUrl(groupId)}/members/{directoryObjectId}/$ref";
-            HttpResponseMessage response = GraphRest.Delete(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            HttpResponseMessage response = GraphRest.Delete(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return response.StatusCode.ToString();
         }
@@ -138,7 +138,7 @@ public class ExchangeGroupSteps
             [PropertyClassification(0, "Settings Override", "Settings")] InputExchangeSettings? settingsOverride)
         {
             string urlExtension = $"{Microsoft365UrlHelper.GetUserUrl(userIdentifier)}/memberOf";
-            string result = GraphRest.Get(new ExchangeSettings(){TokenId = settingsOverride?.TokenId, GraphUrl = settingsOverride?.GraphUrl}, urlExtension);
+            string result = GraphRest.Get(Microsoft365Utility.GetExchangeSettings(settingsOverride), urlExtension);
             
             return JsonHelper<Microsoft365GroupCollection?>.JsonDeserialize(result);
         }


### PR DESCRIPTION
When setting override was null/ignore on input, we were getting null reference exception because we were trying to read InputExchangeSettings object (which is null) and create ExhcnageSettings object out of it to pass on

Fixed it by checking null before creating the ExhcnageSettings object.